### PR TITLE
fix(svd): fall back to zgesvd on zgesdd convergence failure

### DIFF
--- a/include/tci/cytnx_typed_tensor_impl.h
+++ b/include/tci/cytnx_typed_tensor_impl.h
@@ -856,14 +856,18 @@ namespace tci {
     // can fail on ill-conditioned matrices.  Fall back to Gesvd_truncate
     // (zgesvd, QR iteration) on convergence failure.
     std::vector<cytnx::Tensor> svd_result;
+    bool used_fallback = false;
     try {
       svd_result = cytnx::linalg::Svd_truncate(a_reshaped, chi_max, s_min, true, 0, 1);
-    } catch (...) {
+    } catch (const std::exception &) {
+      used_fallback = true;
       svd_result = cytnx::linalg::Gesvd_truncate(a_reshaped, chi_max, s_min, true, true, 0, 1);
     }
 
     if (svd_result.size() < 3) {
-      throw std::runtime_error("trunc_svd: unexpected result size from Svd_truncate");
+      throw std::runtime_error(
+          std::string("trunc_svd: unexpected result size from ") +
+          (used_fallback ? "Gesvd_truncate" : "Svd_truncate"));
     }
 
     // Extract S, U, Vt (order: S, U, V†)

--- a/include/tci/cytnx_typed_tensor_impl.h
+++ b/include/tci/cytnx_typed_tensor_impl.h
@@ -852,9 +852,15 @@ namespace tci {
         {static_cast<cytnx::cytnx_int64>(left_dim), static_cast<cytnx::cytnx_int64>(right_dim)});
 
     // Perform SVD with chi_max constraint
-    // Note: Cytnx's Svd_truncate doesn't support target_trunc_err or chi_min directly,
-    // so we apply chi_max first and then manually truncate based on target_trunc_err and chi_min
-    auto svd_result = cytnx::linalg::Svd_truncate(a_reshaped, chi_max, s_min, true, 0, 1);
+    // Cytnx's Svd_truncate uses LAPACK zgesdd (divide-and-conquer) which
+    // can fail on ill-conditioned matrices.  Fall back to Gesvd_truncate
+    // (zgesvd, QR iteration) on convergence failure.
+    std::vector<cytnx::Tensor> svd_result;
+    try {
+      svd_result = cytnx::linalg::Svd_truncate(a_reshaped, chi_max, s_min, true, 0, 1);
+    } catch (...) {
+      svd_result = cytnx::linalg::Gesvd_truncate(a_reshaped, chi_max, s_min, true, true, 0, 1);
+    }
 
     if (svd_result.size() < 3) {
       throw std::runtime_error("trunc_svd: unexpected result size from Svd_truncate");


### PR DESCRIPTION
## Summary

Wrap `Svd_truncate` (LAPACK `zgesdd`, divide-and-conquer) in a try-catch and fall back to `Gesvd_truncate` (`zgesvd`, QR iteration) on convergence failure.

## Motivation

`zgesdd` can fail with `INFO=1` on ill-conditioned matrices, particularly with OpenBLAS. This has been observed in Trotter MPO construction for large sparse Pauli Hamiltonians (20+ qubits, thousands of terms).

## Test plan

- [x] All downstream tests pass with no regression
- [x] Verified fallback fires and completes successfully on a case that previously crashed