### PR TITLE
test(conformance): adopt tcict bulk macros and expand to all 4 element types

### DIFF
--- a/test/source/conformance_runner.cpp
+++ b/test/source/conformance_runner.cpp
@@ -15,8 +15,12 @@
 
 #include <tcict/adapters/doctest.h>
 
+using CytnxRealF = tci::CytnxTensor<cytnx::cytnx_float>;
 using CytnxRealD = tci::CytnxTensor<cytnx::cytnx_double>;
+using CytnxCplxF = tci::CytnxTensor<cytnx::cytnx_complex64>;
 using CytnxCplxD = tci::CytnxTensor<cytnx::cytnx_complex128>;
 
+TCICT_DOCTEST_REGISTER_REAL(float, CytnxRealF)
 TCICT_DOCTEST_REGISTER_REAL(double, CytnxRealD)
+TCICT_DOCTEST_REGISTER_CPLX(cfloat, CytnxCplxF)
 TCICT_DOCTEST_REGISTER_CPLX(cdouble, CytnxCplxD)

--- a/test/source/conformance_runner.cpp
+++ b/test/source/conformance_runner.cpp
@@ -3,10 +3,10 @@
 // per applicable conformance test; see the tcict adapter header for the
 // suite categorization.
 //
-// The cytnx TCI header must be included before the adapter, because some
-// test templates call non-dependent `tci::` functions (e.g.,
-// `tci::create_context` in the fixture constructor) that are resolved at
-// the adapter's first parsing phase.
+// The backend's TCI header (`<tci/tci.h>`) must be included before the
+// adapter, because some test templates call non-dependent `tci::` functions
+// (e.g., `tci::create_context` in the fixture constructor) that are resolved
+// at the adapter's first parsing phase.
 
 #include <doctest/doctest.h>
 #define TCI_NO_DEPRECATED_API

--- a/test/source/conformance_runner.cpp
+++ b/test/source/conformance_runner.cpp
@@ -11,7 +11,6 @@
 #include <doctest/doctest.h>
 #define TCI_NO_DEPRECATED_API
 #include <tci/tci.h>
-#include <cytnx.hpp>
 
 #include <tcict/adapters/doctest.h>
 

--- a/test/source/conformance_runner.cpp
+++ b/test/source/conformance_runner.cpp
@@ -1,141 +1,22 @@
+// Wires TCICT conformance tests into doctest via the bulk-registration
+// adapter. Each `TCICT_DOCTEST_REGISTER_*` line expands into one `TEST_CASE`
+// per applicable conformance test; see the tcict adapter header for the
+// suite categorization.
+//
+// The cytnx TCI header must be included before the adapter, because some
+// test templates call non-dependent `tci::` functions (e.g.,
+// `tci::create_context` in the fixture constructor) that are resolved at
+// the adapter's first parsing phase.
+
 #include <doctest/doctest.h>
 #define TCI_NO_DEPRECATED_API
 #include <tci/tci.h>
-#include <tcict/tcict.h>
-
 #include <cytnx.hpp>
 
-// Bridge macro: wraps a tcict conformance test function as a doctest TEST_CASE.
-// If the conformance test throws tcict::assertion_error, doctest reports it as FAIL.
-#define TCICT_DOCTEST_CASE(category, test_func, TenT)                                              \
-  TEST_CASE("TCICT: " category " - " #test_func) {                                                \
-    tcict::tci_test_fixture<TenT> fix;                                                             \
-    tcict::tests::test_func<TenT>(fix);                                                            \
-  }
+#include <tcict/adapters/doctest.h>
 
-using CplxTensor = tci::CytnxTensor<cytnx::cytnx_complex128>;
-using RealTensor = tci::CytnxTensor<cytnx::cytnx_double>;
+using CytnxRealD = tci::CytnxTensor<cytnx::cytnx_double>;
+using CytnxCplxD = tci::CytnxTensor<cytnx::cytnx_complex128>;
 
-// --- Construction ---
-TCICT_DOCTEST_CASE("construction", test_zeros, CplxTensor)
-TCICT_DOCTEST_CASE("construction", test_fill, CplxTensor)
-TCICT_DOCTEST_CASE("construction", test_eye, CplxTensor)
-TCICT_DOCTEST_CASE("construction", test_random_inplace, CplxTensor)
-TCICT_DOCTEST_CASE("construction", test_random_outofplace, CplxTensor)
-TCICT_DOCTEST_CASE("construction", test_copy_inplace, CplxTensor)
-TCICT_DOCTEST_CASE("construction", test_copy_outofplace, CplxTensor)
-TCICT_DOCTEST_CASE("construction", test_copy_independence, CplxTensor)
-TCICT_DOCTEST_CASE("construction", test_copy_single_element, CplxTensor)
-TCICT_DOCTEST_CASE("construction", test_copy_large, CplxTensor)
-TCICT_DOCTEST_CASE("construction", test_assign_from_range_row_major, CplxTensor)
-TCICT_DOCTEST_CASE("construction", test_assign_from_range_column_major, CplxTensor)
-
-// --- Read-only getters ---
-TCICT_DOCTEST_CASE("getters", test_order, CplxTensor)
-TCICT_DOCTEST_CASE("getters", test_shape, CplxTensor)
-TCICT_DOCTEST_CASE("getters", test_size, CplxTensor)
-TCICT_DOCTEST_CASE("getters", test_size_bytes, CplxTensor)
-TCICT_DOCTEST_CASE("getters", test_set_get_elem, CplxTensor)
-TCICT_DOCTEST_CASE("getters", test_size_bytes_2x2, CplxTensor)
-
-// --- Miscellaneous ---
-TCICT_DOCTEST_CASE("miscellaneous", test_close_identical, CplxTensor)
-TCICT_DOCTEST_CASE("miscellaneous", test_close_different, CplxTensor)
-TCICT_DOCTEST_CASE("miscellaneous", test_to_range, CplxTensor)
-TCICT_DOCTEST_CASE("miscellaneous", test_show, CplxTensor)
-TCICT_DOCTEST_CASE("miscellaneous", test_convert_same_context, CplxTensor)
-TCICT_DOCTEST_CASE("miscellaneous", test_convert_different_context, CplxTensor)
-TCICT_DOCTEST_CASE("miscellaneous", test_convert_data_integrity, CplxTensor)
-TCICT_DOCTEST_CASE("miscellaneous", test_version, RealTensor)
-
-// --- Construction (allocate, clear, move) ---
-TCICT_DOCTEST_CASE("construction", test_allocate_3d, CplxTensor)
-TCICT_DOCTEST_CASE("construction", test_allocate_2d, CplxTensor)
-TCICT_DOCTEST_CASE("construction", test_allocate_1d, CplxTensor)
-TCICT_DOCTEST_CASE("construction", test_clear_basic, CplxTensor)
-TCICT_DOCTEST_CASE("construction", test_clear_empty, CplxTensor)
-TCICT_DOCTEST_CASE("construction", test_clear_and_reallocate, CplxTensor)
-TCICT_DOCTEST_CASE("construction", test_move_inplace, CplxTensor)
-TCICT_DOCTEST_CASE("construction", test_move_outofplace, CplxTensor)
-TCICT_DOCTEST_CASE("construction", test_move_empty, CplxTensor)
-TCICT_DOCTEST_CASE("construction", test_move_preserves_values, CplxTensor)
-
-// --- I/O ---
-TCICT_DOCTEST_CASE("io", test_save_load_roundtrip, CplxTensor)
-TCICT_DOCTEST_CASE("io", test_load_data_integrity, CplxTensor)
-
-// --- Tensor manipulation ---
-TCICT_DOCTEST_CASE("manipulation", test_shrink_inplace, CplxTensor)
-TCICT_DOCTEST_CASE("manipulation", test_shrink_outofplace, CplxTensor)
-TCICT_DOCTEST_CASE("manipulation", test_shrink_complex_values, CplxTensor)
-TCICT_DOCTEST_CASE("manipulation", test_real_extraction, CplxTensor)
-TCICT_DOCTEST_CASE("manipulation", test_imag_extraction, CplxTensor)
-TCICT_DOCTEST_CASE("manipulation", test_real_imag_inplace, CplxTensor)
-TCICT_DOCTEST_CASE("manipulation", test_cplx_conj_inplace, CplxTensor)
-TCICT_DOCTEST_CASE("manipulation", test_cplx_conj_outofplace, CplxTensor)
-TCICT_DOCTEST_CASE("manipulation", test_to_cplx_outofplace, RealTensor)
-TCICT_DOCTEST_CASE("manipulation", test_to_cplx_inplace, RealTensor)
-TCICT_DOCTEST_CASE("manipulation", test_to_cplx_complex_to_complex, CplxTensor)
-TCICT_DOCTEST_CASE("manipulation", test_for_each_doubling, CplxTensor)
-TCICT_DOCTEST_CASE("manipulation", test_for_each_summation, CplxTensor)
-TCICT_DOCTEST_CASE("manipulation", test_for_each_capture, CplxTensor)
-TCICT_DOCTEST_CASE("manipulation", test_for_each_const, CplxTensor)
-TCICT_DOCTEST_CASE("manipulation", test_for_each_inversion, CplxTensor)
-TCICT_DOCTEST_CASE("manipulation", test_for_each_with_coors, RealTensor)
-TCICT_DOCTEST_CASE("manipulation", test_for_each_with_coors_const, RealTensor)
-TCICT_DOCTEST_CASE("manipulation", test_reshape, CplxTensor)
-TCICT_DOCTEST_CASE("manipulation", test_transpose, CplxTensor)
-TCICT_DOCTEST_CASE("manipulation", test_concatenate_basic, CplxTensor)
-TCICT_DOCTEST_CASE("manipulation", test_concatenate_values, CplxTensor)
-TCICT_DOCTEST_CASE("manipulation", test_concatenate_errors, CplxTensor)
-TCICT_DOCTEST_CASE("manipulation", test_extract_sub, CplxTensor)
-TCICT_DOCTEST_CASE("manipulation", test_extract_sub_errors, CplxTensor)
-TCICT_DOCTEST_CASE("manipulation", test_replace_sub_inplace, CplxTensor)
-TCICT_DOCTEST_CASE("manipulation", test_replace_sub_outofplace, CplxTensor)
-TCICT_DOCTEST_CASE("manipulation", test_replace_sub_errors, CplxTensor)
-TCICT_DOCTEST_CASE("manipulation", test_expand_inplace, CplxTensor)
-TCICT_DOCTEST_CASE("manipulation", test_expand_outofplace, CplxTensor)
-TCICT_DOCTEST_CASE("manipulation", test_expand_invalid_throws, CplxTensor)
-TCICT_DOCTEST_CASE("manipulation", test_diag_vec_to_mat, CplxTensor)
-TCICT_DOCTEST_CASE("manipulation", test_diag_mat_to_vec, CplxTensor)
-TCICT_DOCTEST_CASE("manipulation", test_stack_basic, CplxTensor)
-TCICT_DOCTEST_CASE("manipulation", test_stack_last_axis, CplxTensor)
-TCICT_DOCTEST_CASE("manipulation", test_stack_errors, CplxTensor)
-
-// --- Linear algebra ---
-TCICT_DOCTEST_CASE("linear_algebra", test_norm_identity, CplxTensor)
-TCICT_DOCTEST_CASE("linear_algebra", test_norm_2x2, CplxTensor)
-TCICT_DOCTEST_CASE("linear_algebra", test_linear_combine_uniform, CplxTensor)
-TCICT_DOCTEST_CASE("linear_algebra", test_linear_combine_weighted, CplxTensor)
-TCICT_DOCTEST_CASE("linear_algebra", test_linear_combine_single, CplxTensor)
-TCICT_DOCTEST_CASE("linear_algebra", test_normalize_inplace, CplxTensor)
-TCICT_DOCTEST_CASE("linear_algebra", test_normalize_outofplace, CplxTensor)
-TCICT_DOCTEST_CASE("linear_algebra", test_normalize_edge_cases, CplxTensor)
-TCICT_DOCTEST_CASE("linear_algebra", test_contract_matmul, CplxTensor)
-TCICT_DOCTEST_CASE("linear_algebra", test_contract_dot_product, CplxTensor)
-TCICT_DOCTEST_CASE("linear_algebra", test_contract_outer_product, CplxTensor)
-TCICT_DOCTEST_CASE("linear_algebra", test_qr, CplxTensor)
-TCICT_DOCTEST_CASE("linear_algebra", test_lq, CplxTensor)
-TCICT_DOCTEST_CASE("linear_algebra", test_trunc_svd, CplxTensor)
-TCICT_DOCTEST_CASE("linear_algebra", test_trunc_svd_trunc_err_value, CplxTensor)
-TCICT_DOCTEST_CASE("linear_algebra", test_trunc_svd_trunc_err_no_truncation, CplxTensor)
-TCICT_DOCTEST_CASE("linear_algebra", test_trunc_svd_trunc_err_bounded, CplxTensor)
-TCICT_DOCTEST_CASE("linear_algebra", test_eig_identity, CplxTensor)
-TCICT_DOCTEST_CASE("linear_algebra", test_eigh_identity, CplxTensor)
-TCICT_DOCTEST_CASE("linear_algebra", test_exp_identity, CplxTensor)
-TCICT_DOCTEST_CASE("linear_algebra", test_exp_diagonal, CplxTensor)
-TCICT_DOCTEST_CASE("linear_algebra", test_exp_zero, CplxTensor)
-TCICT_DOCTEST_CASE("linear_algebra", test_exp_anti_hermitian, CplxTensor)
-TCICT_DOCTEST_CASE("linear_algebra", test_exp_errors, CplxTensor)
-TCICT_DOCTEST_CASE("linear_algebra", test_inverse, CplxTensor)
-TCICT_DOCTEST_CASE("linear_algebra", test_inverse_errors, CplxTensor)
-TCICT_DOCTEST_CASE("linear_algebra", test_scale_inplace, CplxTensor)
-TCICT_DOCTEST_CASE("linear_algebra", test_scale_outofplace, CplxTensor)
-TCICT_DOCTEST_CASE("linear_algebra", test_scale_by_zero, CplxTensor)
-TCICT_DOCTEST_CASE("linear_algebra", test_trace_partial, CplxTensor)
-TCICT_DOCTEST_CASE("linear_algebra", test_svd_basic, CplxTensor)
-TCICT_DOCTEST_CASE("linear_algebra", test_svd_reconstruction, CplxTensor)
-TCICT_DOCTEST_CASE("linear_algebra", test_eigvals_diagonal, CplxTensor)
-TCICT_DOCTEST_CASE("linear_algebra", test_eigvals_errors, CplxTensor)
-TCICT_DOCTEST_CASE("linear_algebra", test_eigvalsh_diagonal, CplxTensor)
-TCICT_DOCTEST_CASE("linear_algebra", test_eigvalsh_errors, CplxTensor)
+TCICT_DOCTEST_REGISTER_REAL(double, CytnxRealD)
+TCICT_DOCTEST_REGISTER_CPLX(cdouble, CytnxCplxD)


### PR DESCRIPTION
## Summary

Update the conformance runner to track upstream tcict and exercise the full TCI specification's standard element-type set.

Two commits:

1. **Migrate to bulk-registration adapter** (`1242944`)
   The runner shrinks from ~135 explicit `TCICT_DOCTEST_CASE` lines per type to one register line per type. Submodule bumps `external/tcict` to pull in the bulk-registration macros (`TCICT_DOCTEST_REGISTER_REAL` / `TCICT_DOCTEST_REGISTER_CPLX`, upstream PR [tcict#37](https://github.com/ultimatile/tensor-computing-interface-conformance-test/pull/37)), the local integration check ([tcict#39](https://github.com/ultimatile/tensor-computing-interface-conformance-test/pull/39) closing [tcict#38](https://github.com/ultimatile/tensor-computing-interface-conformance-test/issues/38)), the tolerance category framework ([tcict#40](https://github.com/ultimatile/tensor-computing-interface-conformance-test/pull/40) refs [tcict#32](https://github.com/ultimatile/tensor-computing-interface-conformance-test/issues/32)), and a few smaller fixes ([tcict#34](https://github.com/ultimatile/tensor-computing-interface-conformance-test/pull/34) trunc_svd spec verification, [tcict#35](https://github.com/ultimatile/tensor-computing-interface-conformance-test/pull/35) type-aware epsilon, [tcict#36](https://github.com/ultimatile/tensor-computing-interface-conformance-test/pull/36) imaginary-part assertion guards).

2. **Exercise all four standard TCI element types** (`2339dd1`)
   Register `cytnx_float` and `cytnx_complex64` alongside the existing `cytnx_double` / `cytnx_complex128` instances. The bulk macros expand each register line into one TEST_CASE per applicable conformance test, so the suite grows from 243 cases (2 types) to 460 (4 types) and surfaces backend-side bugs that were previously untested. Bumps `external/tcict` once more to include the upstream fix that lets `std::complex<float>` instantiate the test bodies ([tcict#41](https://github.com/ultimatile/tensor-computing-interface-conformance-test/pull/41)).

## Failure landscape

41 of 460 test cases fail on this checkout. None of the failures are introduced by this PR — the expanded coverage simply makes pre-existing gaps visible. Each is filed as a separate issue:

| Pattern | Tests | Issue |
|---|---|---|
| `tci::exp` returns ~zero for real-typed matrix inputs | `test_exp_*` × {`double`, `float`} | #8 |
| `tci::save` does not persist to extensionless paths; `tci::load` then errors not-found | `test_save_load_roundtrip`, `test_load_data_integrity` × all 4 types | #9 |
| Single-precision SVD / trunc_svd / eig exceed default tolerance | `test_svd_*`, `test_trunc_svd_*`, `test_eig_identity`, `test_eigvals_diagonal` × {`float`, `cfloat`} | #10 |
| `tci::to_cplx` fails on `cytnx_float` inputs | `test_to_cplx_*` × `float` | #11 |
| `tci::trace` returns order-1 instead of order-0 scalar | `test_trace_partial` × all 4 types | #3 (existing) |

## Test plan

- `cmake --build build --target TCITests` succeeds.
- `./build/test/TCITests` reports 460 cases, 419 pass, 41 fail (matching the table above), 1 skipped, 6293 / 6293 assertions pass. The non-zero exit is expected pending the listed cytnx-side fixes.
- The two `cytnx_double` / `cytnx_complex128` failures from before this PR (`test_save_load_*` + `test_trace_partial` on `cytnx_complex128`) reproduce identically; the rest are new visibility, not regressions.

## Risk

The TCITests target exits non-zero on this branch until issues #8, #9, #10, #11 (and the existing #3) are fixed — `ctest` will report failures, the binary returns exit code 1 if invoked directly, and `make integration-check` from upstream tcict ([tcict#39](https://github.com/ultimatile/tensor-computing-interface-conformance-test/pull/39)) surfaces the same failures locally.

The cost is bounded by the current operational state: the test target is already in an "expected non-zero" posture pending the spec-manager decision on the order-0 vs order-1 trace return type (#3). Adding more known-failing tests does not lose a clean-pass signal that is currently in use. Once #3 is resolved upstream and the cytnx fixes for #8 / #9 / #10 / #11 land, the failure count drops naturally; until then, the documented per-issue table is the regression-detection surrogate (any failure outside the listed rows indicates an unintended regression).

If keeping all four element types active becomes inconvenient before all five issues are resolved, the float / complex64 registrations can be hidden behind a `-DTCI_TEST_FLOAT_PRECISION=ON` opt-in flag at that point. The default here keeps them active so the empirical data stays available to the tcict tolerance-calibration follow-up ([tcict#32](https://github.com/ultimatile/tensor-computing-interface-conformance-test/issues/32) deferred items).


