### PR TITLE
refactor: avoid std::function and std::vector<bool> in internal helpers

### DIFF
--- a/include/tci/construction_destruction.h
+++ b/include/tci/construction_destruction.h
@@ -56,9 +56,11 @@ namespace tci {
                          Func&& coors2idx) {
     TenT a = allocate<TenT>(ctx, shape);
 
-    // Generate all coordinate combinations and assign values
-    std::function<void(elem_coors_t<TenT>, std::size_t)> assign_recursive;
-    assign_recursive = [&](elem_coors_t<TenT> current_coords, std::size_t dim) {
+    // Generate all coordinate combinations and assign values.
+    // Self-referencing lambda (Y-combinator form) avoids std::function's
+    // type erasure and heap allocation for the recursive call.
+    auto assign_recursive
+        = [&](auto& self, elem_coors_t<TenT> current_coords, std::size_t dim) -> void {
       if (dim == shape.size()) {
         // Base case: all dimensions set, assign the element
         auto index = std::invoke(coors2idx, current_coords);
@@ -70,13 +72,13 @@ namespace tci {
         // Recursive case: iterate through current dimension
         for (bond_dim_t<TenT> i = 0; i < shape[dim]; ++i) {
           current_coords.push_back(i);
-          assign_recursive(current_coords, dim + 1);
+          self(self, current_coords, dim + 1);
           current_coords.pop_back();
         }
       }
     };
 
-    assign_recursive({}, 0);
+    assign_recursive(assign_recursive, {}, 0);
     return a;
   }
 

--- a/include/tci/cytnx_typed_tensor_impl.h
+++ b/include/tci/cytnx_typed_tensor_impl.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <algorithm>
+#include <cstdint>
 #include <cytnx.hpp>
 #include <limits>
 #include <vector>
@@ -522,7 +523,8 @@ namespace tci {
         = [](size_t rank, const std::vector<bond_label_t<TenT>>& axes_list, const char* which) {
             std::vector<cytnx::cytnx_uint64> axes;
             axes.reserve(axes_list.size());
-            std::vector<bool> seen(rank, false);
+            // uint8_t flag vector instead of std::vector<bool> to avoid proxy reference semantics.
+            std::vector<std::uint8_t> seen(rank, 0);
             for (auto axis : axes_list) {
               if (axis < 0 || static_cast<size_t>(axis) >= rank) {
                 std::ostringstream oss;
@@ -536,7 +538,7 @@ namespace tci {
               if (seen[idx]) {
                 throw std::invalid_argument("contract: duplicate axis index detected");
               }
-              seen[idx] = true;
+              seen[idx] = 1;
               axes.push_back(static_cast<cytnx::cytnx_uint64>(idx));
             }
             return axes;
@@ -550,8 +552,9 @@ namespace tci {
     }
 
     auto collect_free_axes = [](size_t rank, const std::vector<cytnx::cytnx_uint64>& contracted) {
-      std::vector<bool> used(rank, false);
-      for (auto idx : contracted) used[idx] = true;
+      // uint8_t flag vector instead of std::vector<bool> to avoid proxy reference semantics.
+      std::vector<std::uint8_t> used(rank, 0);
+      for (auto idx : contracted) used[idx] = 1;
       std::vector<cytnx::cytnx_uint64> free_axes;
       free_axes.reserve(rank - contracted.size());
       for (size_t i = 0; i < rank; ++i) {
@@ -571,13 +574,14 @@ namespace tci {
         throw std::invalid_argument("contract: output axis specification mismatch");
       }
 
-      std::vector<bool> seen(total_free, false);
+      // uint8_t flag vector instead of std::vector<bool> to avoid proxy reference semantics.
+      std::vector<std::uint8_t> seen(total_free, 0);
       permute_order.reserve(total_free);
       for (auto axis : bd_labs_c) {
         if (axis < 0 || static_cast<size_t>(axis) >= total_free || seen[axis]) {
           throw std::invalid_argument("contract: invalid output axis permutation");
         }
-        seen[axis] = true;
+        seen[axis] = 1;
         permute_order.push_back(static_cast<cytnx::cytnx_uint64>(axis));
       }
     }


### PR DESCRIPTION
## Summary

Two C++17-safe internal cleanups:

- Replace the `std::function` used as a recursive-lambda holder with a self-referencing generic lambda to avoid type-erasure overhead in `assign_from_range`.
- Replace three local `std::vector<bool>` flag arrays in `contract` with `std::vector<std::uint8_t>` to avoid `std::vector<bool>`'s proxy-reference specialization.

Public API and observable behavior are unchanged.

## Changes

- `include/tci/construction_destruction.h`: rewrite the `assign_from_range` coordinate walker as a self-referencing generic lambda (`auto& self` parameter), eliminating the `std::function` holder.
- `include/tci/cytnx_typed_tensor_impl.h`: replace three local `std::vector<bool>` flag arrays in `contract`'s axis-analysis lambdas with `std::vector<std::uint8_t>` and add `<cstdint>`.

## Test plan

- `cmake --build build-debug` clean.
- `./build-debug/test/TCITests`: 6300 / 6300 assertions pass (test-case counts identical to `main`).
